### PR TITLE
Self encryption benchmark test

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -31,9 +31,6 @@ use self_encryption::SelfEncryptor;
 use self_encryption::Storage;
 use self_encryption::datamap::DataMap as DataMap;
 
-/// BENCH_MAX_FILE_MAGN benchmarks file sizes up to order (1024)^7 bytes 
-pub const BENCH_MAX_FILE_MAGN: u32 = 7;
-
 //TODO(ben 2015-03-24): replace copy from src/lib.rs mod test to properly import and reuse
 fn random_string(length: u64) -> String {
   (0..length).map(|_| (0x20u8 + (rand::random::<f32>() * 96.0) as u8) as char).collect()

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,0 +1,201 @@
+// Copyright 2014-2015 MaidSafe.net limited
+//
+// This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+// directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+// available at: http://www.maidsafe.net/licenses
+//
+// Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied.
+//
+// See the Licences for the specific language governing permissions and limitations relating to
+// use of the MaidSafe
+// Software.
+
+// the test names contain MB, KB which should retain capitalisation
+#![allow(non_snake_case)]
+
+#![feature(test)]
+#![allow(dead_code)]
+extern crate test;
+extern crate rand;
+extern crate self_encryption;
+
+use test::Bencher;
+use self_encryption::SelfEncryptor;
+use self_encryption::Storage;
+use self_encryption::datamap::DataMap as DataMap;
+
+/// BENCH_MAX_FILE_MAGN benchmarks file sizes up to order (1024)^7 bytes 
+pub const BENCH_MAX_FILE_MAGN: u32 = 7;
+
+//TODO(ben 2015-03-24): replace copy from src/lib.rs mod test to properly import and reuse
+fn random_string(length: u64) -> String {
+  (0..length).map(|_| (0x20u8 + (rand::random::<f32>() * 96.0) as u8) as char).collect()
+}
+
+struct Entry {
+  name: Vec<u8>,
+  data: Vec<u8>
+}
+
+struct MyStorage {
+  entries: Vec<Entry>
+}
+
+impl MyStorage {
+  pub fn new() -> MyStorage {
+    MyStorage { entries: Vec::new() }
+  }
+
+  pub fn has_chunk(&self, name: Vec<u8>) -> bool {
+    for entry in self.entries.iter() {
+      if entry.name == name { return true }
+    }
+    false
+  }
+}
+
+impl Storage for MyStorage {
+  fn get(&self, name: Vec<u8>) -> Vec<u8> {
+    for entry in self.entries.iter() {
+      if entry.name == name { return entry.data.to_vec() }
+    }
+
+    vec![]
+  }
+
+  fn put(&mut self, name: Vec<u8>, data: Vec<u8>) {
+    self.entries.push(Entry { name : name, data : data })
+  }
+}
+// end of copy from src/lib.rs
+
+#[bench]
+fn bench_write_then_read_a_200B(b: &mut Bencher) {
+  let mut my_storage = MyStorage::new();
+  let string_len = 200 as u64;
+  b.iter(|| {
+  	let mut data_map = DataMap::None;
+  	let the_string = random_string(string_len);
+    {
+      let mut se = SelfEncryptor::new(&mut my_storage as &mut Storage, DataMap::None);
+      se.write(&the_string, 0);
+      data_map = se.close();
+    }
+    let mut new_se = SelfEncryptor::new(&mut my_storage as &mut Storage, data_map);
+    let fetched = new_se.read(0, string_len);
+    assert_eq!(fetched, the_string);
+  });
+  b.bytes = 2 * string_len;
+}
+
+#[bench]
+fn bench_write_then_read_b_1KB(b: &mut Bencher) {
+  let mut my_storage = MyStorage::new();
+  let string_len = 1024 as u64;
+  b.iter(|| {
+  	let mut data_map = DataMap::None;
+  	let the_string = random_string(string_len);
+    {
+      let mut se = SelfEncryptor::new(&mut my_storage as &mut Storage, DataMap::None);
+      se.write(&the_string, 0);
+      data_map = se.close();
+    }
+    let mut new_se = SelfEncryptor::new(&mut my_storage as &mut Storage, data_map);
+    let fetched = new_se.read(0, string_len);
+    assert_eq!(fetched, the_string);
+  });
+  b.bytes = 2 * string_len;
+}
+
+#[bench]
+fn bench_write_then_read_c_1MB(b: &mut Bencher) {
+  let mut my_storage = MyStorage::new();
+  let string_len = 1024 * 1024 as u64;
+  b.iter(|| {
+  	let mut data_map = DataMap::None;
+  	let the_string = random_string(string_len);
+    {
+      let mut se = SelfEncryptor::new(&mut my_storage as &mut Storage, DataMap::None);
+      se.write(&the_string, 0);
+      data_map = se.close();
+    }
+    let mut new_se = SelfEncryptor::new(&mut my_storage as &mut Storage, data_map);
+    let fetched = new_se.read(0, string_len);
+    assert_eq!(fetched, the_string);
+  });
+  b.bytes = 2 * string_len;
+}
+
+#[bench]
+fn bench_write_then_read_d_3MB(b: &mut Bencher) {
+  let mut my_storage = MyStorage::new();
+  let string_len = 3 * 1024 * 1024 as u64;
+  b.iter(|| {
+  	let mut data_map = DataMap::None;
+  	let the_string = random_string(string_len);
+    {
+      let mut se = SelfEncryptor::new(&mut my_storage as &mut Storage, DataMap::None);
+      se.write(&the_string, 0);
+      data_map = se.close();
+    }
+    let mut new_se = SelfEncryptor::new(&mut my_storage as &mut Storage, data_map);
+    let fetched = new_se.read(0, string_len);
+    assert_eq!(fetched, the_string);
+  });
+  b.bytes = 2 * string_len;
+}
+
+#[bench]
+fn bench_write_then_read_e_10MB(b: &mut Bencher) {
+  let mut my_storage = MyStorage::new();
+  let string_len = 10 * 1024 * 1024 as u64;
+  b.iter(|| {
+  	let mut data_map = DataMap::None;
+  	let the_string = random_string(string_len);
+    {
+      let mut se = SelfEncryptor::new(&mut my_storage as &mut Storage, DataMap::None);
+      se.write(&the_string, 0);
+      data_map = se.close();
+    }
+    let mut new_se = SelfEncryptor::new(&mut my_storage as &mut Storage, data_map);
+    let fetched = new_se.read(0, string_len);
+    assert_eq!(fetched, the_string);
+  });
+  b.bytes = 2 * string_len;
+}
+
+/*#[bench]
+fn bench_write_then_read_range(b: &mut Bencher) {
+  let mut my_storage = MyStorage::new();
+  let string_range = vec![     512 * 1024,
+  						  1 * 1024 * 1024,
+  						  2 * 1024 * 1024,
+  						  3 * 1024 * 1024,
+  						  4 * 1024 * 1024,
+  						  5 * 1024 * 1024,
+  						  6 * 1024 * 1024];
+  for string_len in string_range {
+    b.iter(|| {
+  	  let mut data_map = DataMap::None;
+      let the_string = random_string(string_len);
+      {
+        let mut se = SelfEncryptor::new(&mut my_storage as &mut Storage, DataMap::None);
+        se.write(&the_string, 0);
+        data_map = se.close();
+      }
+      let mut new_se = SelfEncryptor::new(&mut my_storage as &mut Storage, data_map);
+      let fetched = new_se.read(0, string_len);
+      assert_eq!(fetched, the_string);
+    });
+    // write and read the data
+    b.bytes = 2*string_len;
+  }
+}
+*/

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -21,7 +21,7 @@
 #![allow(non_snake_case)]
 
 #![feature(test)]
-#![allow(dead_code)]
+#![allow(dead_code, unused_assignments)]
 extern crate test;
 extern crate rand;
 extern crate self_encryption;
@@ -171,7 +171,8 @@ fn bench_write_then_read_e_10MB(b: &mut Bencher) {
   b.bytes = 2 * string_len;
 }
 
-/*#[bench]
+/*  The assert fails !!
+#[bench]
 fn bench_write_then_read_range(b: &mut Bencher) {
   let mut my_storage = MyStorage::new();
   let string_range = vec![     512 * 1024,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ struct Chunks {
 pub trait Storage {
   // TODO : the trait for fn get shall be Option<Vec<u8>> to cover the situation that cannot
   //        fetched requested content. Instead, the current implementation return empty Vec
-  /// Fetc hthe data bearing the name
+  /// Fetch the data bearing the name
   fn get(&self, name: Vec<u8>) -> Vec<u8>;
 
   /// Insert the data bearing the name

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ struct Chunks {
 pub trait Storage {
   // TODO : the trait for fn get shall be Option<Vec<u8>> to cover the situation that cannot
   //        fetched requested content. Instead, the current implementation return empty Vec
-  /// Fetct the data bearing the name
+  /// Fetc hthe data bearing the name
   fn get(&self, name: Vec<u8>) -> Vec<u8>;
 
   /// Insert the data bearing the name
@@ -154,7 +154,7 @@ impl<'a> SelfEncryptor<'a> {
   pub fn get_storage(&'a mut self) -> &'a mut Storage { self.storage }
 
   /// Write method mirrors a posix type write mechanism
-  /// loosly mimics filsystem interface for easy connection to FUSE like
+  /// loosely mimics filsystem interface for easy connection to FUSE like
   /// programs as well as fine grained access to system level libraries for developers.
   /// The input data will be written from the specified position (starts from 0)
   pub fn write(&mut self, data: &str, position: u64) {
@@ -177,7 +177,7 @@ impl<'a> SelfEncryptor<'a> {
   }
 
   /// returning DataMap, which is the info required to recover encrypted content from storage.
-  /// Content temporarily held in self_encryptor will only got flushed into storage when this
+  /// Content temporarily held in self_encryptor will only get flushed into storage when this
   /// function got called.
   pub fn close(mut self) -> datamap::DataMap {
     if self.file_size < (3 * MIN_CHUNK_SIZE) as u64 {
@@ -432,6 +432,7 @@ impl<'a> SelfEncryptor<'a> {
 #[cfg(test)]
 #[allow(dead_code, unused_variables, unused_assignments)]
 mod test {
+
   use super::*;
 
   fn random_string(length: u64) -> String {


### PR DESCRIPTION
- separate bench mark tests for different file sizes gives more reliable measurements, given the intended use-case of #[bench]
- small string length suffers from overhead to create and recreate SelfEncryptor
- 50MB file size does not converge on benchmark test; not to be confused with passing unit test
- repeatable assert_eq!(fetched, original_string) failure on looping over bench.iter closure. To be further investigated, test commented out for now.  Arguably also not a good 'unit benchmark' test

ToDo: hard-copied private helper functions (or public in private mod test) explicitly into benches/lib.rs; should be improved.
