### PR TITLE
Appveyor Fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,7 @@ platform:
   - x64
 environment:
   RUST_INSTALL_DIR: C:\Rust
-  matrix:
-    - RUST_INSTALL_TRIPLE: i686-pc-windows-gnu
+  matrix:    
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-gnu
 
 install:
@@ -11,8 +10,7 @@ install:
   - cmd: rust-1.0.0-beta-%RUST_INSTALL_TRIPLE%.exe /VERYSILENT /NORESTART /COMPONENTS="rust,gcc,cargo" /DIR="%RUST_INSTALL_DIR%"
   - cmd: SET PATH=%PATH%;%RUST_INSTALL_DIR%\bin;
   - rustc -V
-  - cargo -V
-  - cinst 7zip.commandline -x86
+  - cargo -V  
   - ps: if($env:RUST_INSTALL_TRIPLE -eq 'x86_64-pc-windows-gnu') {
          Start-FileDownload "http://libgd.blob.core.windows.net/mingw/mingw-w64-dgn-x86_64-20141001.7z";
           7z x -oC:\ mingw-w64-dgn-x86_64-20141001.7z;


### PR DESCRIPTION
7Zip installation command is removed. Appveyor, by default ships with z-zip. Win32 removed from the matrix